### PR TITLE
Add debug mode and rerun ability to dashboard

### DIFF
--- a/run_workflow.py
+++ b/run_workflow.py
@@ -6,6 +6,7 @@ import importlib
 import sys
 from pathlib import Path
 from typing import Any, Dict, Mapping
+import time
 
 import yaml
 
@@ -40,28 +41,69 @@ def load_workflow(path: str | Path) -> list[dict[str, Any]]:
     return steps
 
 
-def run_workflow(path: str | Path) -> None:
+def execute_step(step: Mapping[str, Any], idx: int, debug: bool = False) -> Dict[str, Any]:
+    """Run a single workflow step and return execution details."""
+    if not isinstance(step, Mapping):
+        raise ValueError(f"Step {idx} must be a mapping")
+
+    agent_name = step.get("agent")
+    if not agent_name:
+        raise ValueError(f"Step {idx} missing 'agent' key")
+
+    params = step.get("parameters") or {}
+    cls = AGENT_REGISTRY.get(agent_name)
+    if cls is None:
+        raise ValueError(
+            f"Agent '{agent_name}' not found. Available agents: {list(AGENT_REGISTRY)}"
+        )
+
+    agent = cls(params)
+    agent.log(f"Executing step {idx}")
+
+    start = time.perf_counter()
+    success = True
+    output: Any = None
+    error: str | None = None
+    try:
+        output = agent.run()
+    except Exception as exc:  # pylint: disable=broad-except
+        success = False
+        error = str(exc)
+        agent.log(f"Error during step {idx}: {error}")
+    end = time.perf_counter()
+
+    result = {
+        "index": idx,
+        "agent": agent_name,
+        "parameters": params,
+        "output": output,
+        "success": success,
+        "error": error,
+        "time_taken": end - start,
+        "step": step,
+    }
+
+    if debug:
+        print(result)
+
+    return result
+
+
+def run_workflow(path: str | Path, debug: bool = False) -> list[Dict[str, Any]]:
     """Execute all steps in the given workflow file."""
     steps = load_workflow(path)
+    results = []
     for idx, step in enumerate(steps, 1):
-        if not isinstance(step, Mapping):
-            raise ValueError(f"Step {idx} must be a mapping")
-        agent_name = step.get("agent")
-        if not agent_name:
-            raise ValueError(f"Step {idx} missing 'agent' key")
-        params = step.get("parameters") or {}
-        cls = AGENT_REGISTRY.get(agent_name)
-        if cls is None:
-            raise ValueError(
-                f"Agent '{agent_name}' not found. Available agents: {list(AGENT_REGISTRY)}"
-            )
-        agent = cls(params)
-        agent.log(f"Executing step {idx}")
-        agent.run()
+        results.append(execute_step(step, idx, debug=debug))
+    return results
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python run_workflow.py <workflow.yaml>")
-        sys.exit(1)
-    run_workflow(sys.argv[1])
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run an automation workflow")
+    parser.add_argument("workflow", help="Path to workflow YAML file")
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    args = parser.parse_args()
+
+    run_workflow(args.workflow, debug=args.debug)


### PR DESCRIPTION
## Summary
- expand `run_workflow` with `execute_step` helper that collects debug info
- allow `run_workflow` CLI and API to run in debug mode
- update Streamlit dashboard with a Debug mode toggle
- display per-step results including inputs, outputs, time taken and errors
- add ability to rerun a failed step from the dashboard

## Testing
- `python -m py_compile run_workflow.py dashboard/app.py agents/automation_agent.py`
- `python run_workflow.py workflows/agent_workflow.yaml --debug` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_685c1971d90c8332bc5da991740fb6d4